### PR TITLE
mod: use instrumentation instead actions

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,9 +1,5 @@
 'use server'
 
-import { setKUNGalgameTask } from '~/server/cron'
-
-setKUNGalgameTask()
-
 import { getNSFWHeader } from '~/utils/actions/getNSFWHeader'
 import { getHomeData } from '~/app/api/home/route'
 

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,6 @@
+export const register = async () => {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { setKUNGalgameTask } = await import('~/server/cron')
+    setKUNGalgameTask()
+  }
+}

--- a/server/tasks/setCleanupTask.ts
+++ b/server/tasks/setCleanupTask.ts
@@ -21,7 +21,7 @@ const deleteOldFilesAndFolders = async (dir: string) => {
 
       const subEntries = await fs.readdir(fullPath)
       if (subEntries.length === 0) {
-        await fs.rmdir(fullPath)
+        await fs.rm(fullPath)
       }
     } else if (entry.isFile()) {
       if (await isOlderThanOneDay(fullPath)) {


### PR DESCRIPTION
## Changes

- Removed the call to `setKUNGalgameTask` from `app/action.ts`
- Created `instrumentation.ts` and moved the `setKUNGalgameTask` invocation to the correct runtime  
  (ref: [Next.js documentation - instrumentation#importing-runtime-specific-code](https://nextjs.org/docs/app/guides/instrumentation#importing-runtime-specific-code))

## Testing

- [x] Build succeeded  
- [x] Verified the function call is correctly triggered via `console.log()`

## Impact

- Affects the invocation location of the `setCleanupTask` function in `server/tasks/setCleanupTask.ts`
